### PR TITLE
[HYPER-11] fix: increase healthcheck timeout and document security env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ temp/
 
 # AI tools
 .opencode/
+.vercel

--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ EXTERNAL_BASE_URL=http://localhost:8080
 # Admin access (comma-separated DIDs)
 ADMIN_DIDS=did:plc:your-did-here
 
+# Security — required for session encryption (min 64 chars)
+SECRET_KEY_BASE=your-secret-key-at-least-64-characters-long-generate-with-openssl-rand
+
+# Proxy auth — set to true when running behind a trusted reverse proxy
+# (e.g. Next.js frontend on Vercel) that sets the X-User-DID header.
+# WARNING: Never enable this when the server is directly exposed to the internet.
+TRUST_PROXY_HEADERS=false
+
+# WebSocket origins — comma-separated allowed origins for subscriptions.
+# Empty = same-origin only. Set to "*" for development.
+# ALLOWED_ORIGINS=https://your-frontend.vercel.app
+
 # Jetstream (real-time indexing)
 # Collections are auto-discovered from registered lexicons
 # Or specify manually:

--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,6 @@ builder = "dockerfile"
 
 [deploy]
 healthcheckPath = "/health"
-healthcheckTimeout = 3
+healthcheckTimeout = 10
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary

- Increase Railway `healthcheckTimeout` from 3s to 10s — startup takes longer now that 15 lexicons are loaded from the database on boot, causing the healthcheck to fail.
- Document `TRUST_PROXY_HEADERS`, `ALLOWED_ORIGINS`, and `SECRET_KEY_BASE` in the README Configuration section. These were introduced in the security fix (0d95edf) but never documented, which caused the 400 errors on the Vercel frontend after redeployment.
- Add `.vercel` to `.gitignore`.

## Context

After migrating data from SQLite to PostgreSQL on Railway, the service started returning 400 "admin privileges required" errors because `TRUST_PROXY_HEADERS` was not set (it was added in the security fix but defaults to `false`). This has now been set on Railway via `railway variables --set`.

The healthcheck timeout of 3 seconds was insufficient because the new deployment loads 15 lexicons from the database at startup, pushing boot time past the healthcheck window.