### PR TITLE
[HYPER-11] fix: WebSocket origin checker rejects cross-origin connections when ALLOWED_ORIGINS is unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,9 +29,21 @@ DATABASE_URL=sqlite:data/hypergoat.db
 # IMPORTANT: This MUST be persistent across restarts or sessions will be invalidated
 SECRET_KEY_BASE=CHANGE_ME_TO_A_RANDOM_64_CHARACTER_STRING_USE_OPENSSL_RAND
 
+# Trust X-User-DID header from reverse proxy for authentication
+# DANGEROUS: only enable when running behind a trusted reverse proxy
+# TRUST_PROXY_HEADERS=false
+
+# Allowed origins for CORS and WebSocket connections (comma-separated)
+# Empty or unset = allow all origins. Set explicit origins in production.
+# Examples: https://myapp.com,https://admin.myapp.com
+# ALLOWED_ORIGINS=
+
 # Admin DIDs (comma-separated) - users with admin access to the dashboard
 # Example: did:plc:qc42fmqqlsmdq7jiypiiigww is daviddao.org
 ADMIN_DIDS=did:plc:qc42fmqqlsmdq7jiypiiigww
+
+# Domain DID for server identity (defaults to did:web:{HOST})
+# DOMAIN_DID=
 
 # =============================================================================
 # OAuth Configuration
@@ -53,8 +65,22 @@ ADMIN_DIDS=did:plc:qc42fmqqlsmdq7jiypiiigww
 # OAUTH_LOOPBACK_MODE=true
 
 # =============================================================================
+# Lexicon Configuration
+# =============================================================================
+
+# Directory to load lexicon JSON files from (default: testdata/lexicons)
+# LEXICON_DIR=
+
+# =============================================================================
 # Jetstream Configuration
 # =============================================================================
+
+# Jetstream WebSocket URL (default: wss://jetstream2.us-west.bsky.network/subscribe)
+# JETSTREAM_URL=
+
+# Collections to subscribe to via Jetstream (comma-separated NSIDs)
+# If not set, uses collections from registered lexicons
+# JETSTREAM_COLLECTIONS=
 
 # Disable Jetstream cursor tracking (useful in development to avoid
 # backfilling events from previous sessions)
@@ -65,11 +91,20 @@ ADMIN_DIDS=did:plc:qc42fmqqlsmdq7jiypiiigww
 # Backfill Configuration
 # =============================================================================
 
+# Run backfill on server start
+# BACKFILL_ON_START=false
+
+# Collections to backfill (comma-separated, defaults to JETSTREAM_COLLECTIONS)
+# BACKFILL_COLLECTIONS=
+
 # Relay URL for discovering repos (com.atproto.sync.listReposByCollection)
 # BACKFILL_RELAY_URL=https://relay1.us-west.bsky.network
 
 # PLC directory URL for resolving DIDs
 # BACKFILL_PLC_URL=https://plc.directory
+
+# Concurrent requests per PDS during backfill
+# BACKFILL_PDS_CONCURRENCY=4
 
 # Global maximum concurrent HTTP requests (prevents overwhelming network)
 # Higher = faster but more resource intensive
@@ -85,6 +120,16 @@ ADMIN_DIDS=did:plc:qc42fmqqlsmdq7jiypiiigww
 
 # Maximum concurrent DID resolutions during discovery phase
 # BACKFILL_MAX_REPOS=50
+
+# Timeout per repo in milliseconds
+# BACKFILL_REPO_TIMEOUT=60000
+
+# =============================================================================
+# PLC Directory
+# =============================================================================
+
+# PLC directory URL for DID resolution (default: https://plc.directory)
+# PLC_DIRECTORY_URL=
 
 # =============================================================================
 # External Services (Defaults configured via Admin UI)

--- a/internal/graphql/subscription/handler.go
+++ b/internal/graphql/subscription/handler.go
@@ -66,9 +66,15 @@ func NewHandler(schema *graphql.Schema, pubsub *PubSub, allowedOrigins []string)
 
 // makeOriginChecker returns a CheckOrigin function based on the allowed origins list.
 func makeOriginChecker(allowedOrigins []string) func(r *http.Request) bool {
-	// If explicitly set to "*", allow all origins (development mode)
-	if len(allowedOrigins) == 1 && allowedOrigins[0] == "*" {
-		slog.Warn("WebSocket CheckOrigin allows all origins (development mode)")
+	// No origins configured or explicitly set to "*": allow all origins.
+	// This matches the CORS middleware default behavior. To restrict origins,
+	// set ALLOWED_ORIGINS to a comma-separated list of specific origins.
+	if len(allowedOrigins) == 0 || (len(allowedOrigins) == 1 && allowedOrigins[0] == "*") {
+		if len(allowedOrigins) == 0 {
+			slog.Warn("WebSocket CheckOrigin allows all origins (ALLOWED_ORIGINS not configured)")
+		} else {
+			slog.Warn("WebSocket CheckOrigin allows all origins (ALLOWED_ORIGINS=\"*\")")
+		}
 		return func(r *http.Request) bool {
 			return true
 		}

--- a/internal/graphql/subscription/handler_test.go
+++ b/internal/graphql/subscription/handler_test.go
@@ -1,0 +1,79 @@
+package subscription
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestMakeOriginChecker(t *testing.T) {
+	tests := []struct {
+		name           string
+		allowedOrigins []string
+		requestOrigin  string
+		want           bool
+	}{
+		{
+			name:           "nil origins allows all",
+			allowedOrigins: nil,
+			requestOrigin:  "https://example.com",
+			want:           true,
+		},
+		{
+			name:           "empty origins allows all",
+			allowedOrigins: []string{},
+			requestOrigin:  "https://example.com",
+			want:           true,
+		},
+		{
+			name:           "wildcard allows all",
+			allowedOrigins: []string{"*"},
+			requestOrigin:  "https://example.com",
+			want:           true,
+		},
+		{
+			name:           "no origin header always allowed",
+			allowedOrigins: []string{"https://allowed.com"},
+			requestOrigin:  "",
+			want:           true,
+		},
+		{
+			name:           "matching origin allowed",
+			allowedOrigins: []string{"https://allowed.com"},
+			requestOrigin:  "https://allowed.com",
+			want:           true,
+		},
+		{
+			name:           "non-matching origin rejected",
+			allowedOrigins: []string{"https://allowed.com"},
+			requestOrigin:  "https://evil.com",
+			want:           false,
+		},
+		{
+			name:           "multiple origins one matches",
+			allowedOrigins: []string{"https://a.com", "https://b.com"},
+			requestOrigin:  "https://b.com",
+			want:           true,
+		},
+		{
+			name:           "multiple origins none match",
+			allowedOrigins: []string{"https://a.com", "https://b.com"},
+			requestOrigin:  "https://c.com",
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := makeOriginChecker(tt.allowedOrigins)
+			req, _ := http.NewRequest("GET", "/graphql/ws", nil)
+			if tt.requestOrigin != "" {
+				req.Header.Set("Origin", tt.requestOrigin)
+			}
+			got := checker(req)
+			if got != tt.want {
+				t.Errorf("makeOriginChecker(%v) with origin %q = %v, want %v",
+					tt.allowedOrigins, tt.requestOrigin, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Fix WebSocket 403 for cross-origin clients** (e.g. impactindexer.org): When `ALLOWED_ORIGINS` is not configured, the CORS middleware allowed all origins but the WebSocket `CheckOrigin` rejected all cross-origin connections. Now both default to allow-all, matching pre-security-fix behavior. Closes #3.
- **Document all 11 missing env vars in `.env.example`**: `ALLOWED_ORIGINS`, `TRUST_PROXY_HEADERS`, `DOMAIN_DID`, `LEXICON_DIR`, `JETSTREAM_URL`, `JETSTREAM_COLLECTIONS`, `BACKFILL_ON_START`, `BACKFILL_COLLECTIONS`, `BACKFILL_PDS_CONCURRENCY`, `BACKFILL_REPO_TIMEOUT`, `PLC_DIRECTORY_URL`.

## Root Cause

PR #19 (security fixes) tightened `makeOriginChecker` in `subscription/handler.go` to iterate over configured origins. When `ALLOWED_ORIGINS` is empty (the default), the list is `nil`, so the loop matches nothing and every cross-origin WebSocket upgrade gets **403 Forbidden**.

The CORS middleware has the opposite default — empty origins means allow all (`Access-Control-Allow-Origin: *`). This inconsistency meant HTTP GraphQL queries worked from any origin but WebSocket subscriptions were silently blocked.

## Testing

- Added `handler_test.go` with table-driven tests covering: nil origins, empty origins, wildcard, matching, non-matching, and multi-origin scenarios.
- Verified against `hyperindex.test.certified.app`: `Origin: https://impactindexer.org` returned 403 before the fix.